### PR TITLE
#6 ログイン認証を作るためにpassportを使ったJWTの設定

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,14 @@ import { PrismaClient } from '@prisma/client';
 import { validate } from 'email-validator';
 
 passport.use(
-  new StrategyLocal((email, password, done) => {
-    done(null, false); //ログイン成功時はfalseの部分がユーザー情報に書き換わる。失敗時はfalse
+  new StrategyLocal((email: string, password: string, done) => {
+    if (email && password) {
+      return done(null, email && password); //ログイン成功時はfalseの部分がユーザー情報に書き換わる。失敗時はfalse
+    } else {
+      return done(null, false, {
+        message: '入力情報が間違っています。',
+      });
+    }
   })
 );
 


### PR DESCRIPTION
# Issue URL

#6 

# このPRの対応範囲

- passportを使ったJWTの基本設定をする。
- Expressの設定変更をする。
[やっていないこと]
- routerの設定をすることは別のIssueで実装予定。

# 変更理由・変更内容

- passportを使ったJWTの基本設定をする。
- Expressでpassportの初期化をする。