### PR TITLE
#13 JWT Tokenをフロント側へ送ることに成功した

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/src/index.ts",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        }
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,10 @@
 require('dotenv').config();
-
-import passport from 'passport';
-import { Strategy as StrategyLocal } from 'passport-local';
-import { ExtractJwt, Strategy as StrategyJWT } from 'passport-jwt';
+import { passport } from './passport';
 
 import express from 'express';
 import { sendRegistrationAuthEmail } from './mailSender';
 import { sendNoticeRegistrationAuthPassword } from './mailSenderCompleteRegistration';
-import { PrismaClient } from '@prisma/client';
+
 import { validate } from 'email-validator';
 import { prisma } from '../src/prisma';
 import AuthRouter from './route/AuthRouter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,38 +10,13 @@ import { sendNoticeRegistrationAuthPassword } from './mailSenderCompleteRegistra
 import { PrismaClient } from '@prisma/client';
 import { validate } from 'email-validator';
 import { prisma } from '../src/prisma';
-//仮設定
 import AuthRouter from './route/AuthRouter';
-// import B_Router from '';
-// import C_Router from '';
+import bcrypt from 'bcrypt';
 
-passport.use(
-  new StrategyLocal((email: string, password: string, done) => {
-    if (email && password) {
-      return done(null, email && password); //ログイン成功時はfalseの部分がユーザー情報に書き換わる。失敗時はfalse
-    } else {
-      return done(null, false, {
-        message: '入力情報が間違っています。',
-      });
-    }
-  })
-);
-
-passport.use(
-  new StrategyJWT(
-    {
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.STRATEGYJWT_SECRET_KEY,
-    },
-    (payload, done) => {
-      done(null, payload);
-    }
-  )
-);
 const app: express.Express = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-const bcrypt = require('bcrypt');
+
 //CORS対応（というか完全無防備：本番環境ではだめ絶対）
 app.use(
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -55,8 +30,6 @@ app.use(passport.initialize());
 
 // routerを追加
 app.use('/auth', AuthRouter); // /authから始まるURL
-// app.use('/b', B_Router);
-// app.use('/c', passport.authenticate('jwt', { session: false }, C_Router));
 
 app.listen(3003, () => {
   console.log('Start on port 3003.');
@@ -104,7 +77,7 @@ app.post(
 app.get(
   '/registrations',
   async (req: express.Request, res: express.Response) => {
-    const token = req.query.token;
+    const token = String(req.query.token);
     const registration = await prisma.registration.findUnique({
       where: { token },
     });

--- a/src/passport.ts
+++ b/src/passport.ts
@@ -1,0 +1,39 @@
+import passport from 'passport';
+import { prisma } from '../src/prisma';
+import { Strategy as StrategyLocal } from 'passport-local';
+import { ExtractJwt, Strategy as StrategyJWT } from 'passport-jwt';
+
+import bcrypt from 'bcrypt';
+
+passport.use(
+  new StrategyLocal(
+    { usernameField: 'email', session: false },
+    async (email: string, password: string, done) => {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) {
+        return done(new Error('ログイン情報が正しくありません。'), null);
+      }
+      const isOK = await bcrypt.compare(password, user?.password);
+
+      if (isOK) {
+        return done(null, user); //ログイン成功時はfalseの部分がユーザー情報に書き換わる。失敗時はfalse
+      } else {
+        return done(new Error('ログイン情報が正しくありません。'), null);
+      }
+    }
+  )
+);
+
+passport.use(
+  new StrategyJWT(
+    {
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.STRATEGYJWT_SECRET_KEY,
+    },
+    (payload, done) => {
+      done(null, payload);
+    }
+  )
+);
+
+export { passport };

--- a/src/route/AuthRouter.ts
+++ b/src/route/AuthRouter.ts
@@ -9,13 +9,13 @@ const router = express.Router();
 
 const bcrypt = require('bcrypt');
 
-router.get('/login', async (req, res, next) => {
-  const email = req.body.email;
-  console.log('email', email);
+// router.get('/login', async (req, res, next) => {
+//   const email = req.body.email;
+//   console.log('email', email);
 
-  const password = req.body.password;
-  const user = await prisma.user.findUnique({ where: { email, id: '' } });
-});
+//   const password = req.body.password;
+//   const user = await prisma.user.findUnique({ where: { email, id: '' } });
+// });
 
 router.post(
   '/login',

--- a/src/route/AuthRouter.ts
+++ b/src/route/AuthRouter.ts
@@ -1,8 +1,8 @@
+import { User } from '@prisma/client';
 import express from 'express';
 
 import jwt from 'jsonwebtoken';
 import passport from 'passport';
-// import passport from '../lib/security';
 import { prisma } from '../prisma';
 
 const router = express.Router();
@@ -21,15 +21,13 @@ router.post(
   '/login',
   passport.authenticate('local', {
     session: false,
-    successReturnToOrRedirect: '/',
-    failureRedirect: '/login',
-    failureMessage: true,
   }),
   async (req, res, next) => {
     // 1 jwtのtokenを作成 passwordはペイロードに含めない
     const email = req.body.email;
     const password = req.body.password;
-    const user = await prisma.user.findUnique({ where: { email } });
+    const user = req.user as User;
+    // const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
       throw new Error('ログイン情報が正しくありません。');
     }
@@ -38,10 +36,8 @@ router.post(
       throw new Error('ログイン情報が正しくありません。');
     }
     // const payload = { email: user.email, id: user.id };
+
     const payload = { email: user.email };
-    console.log('-------------------');
-    console.log('payload', payload);
-    console.log('-------------------');
     const token = jwt.sign(
       payload,
       process.env.STRATEGYJWT_SECRET_KEY as string,

--- a/src/route/AuthRouter.ts
+++ b/src/route/AuthRouter.ts
@@ -14,7 +14,7 @@ router.get('/login', async (req, res, next) => {
   console.log('email', email);
 
   const password = req.body.password;
-  const user = await prisma.user.findUnique({ where: { email } });
+  const user = await prisma.user.findUnique({ where: { email, id: '' } });
 });
 
 router.post(


### PR DESCRIPTION
# Issue URL

#13

# このPRの対応範囲

- JWT Tokenをフロント側へ送り、ログインユーザーがログインしている状態を保持する。
(Refresh Tokenは別のPRで対応予定)
- テストユーザーを作成してログインできるかを確認する。

# 変更内容・変更理由

- Node.jsのデバッグを用意。
- JWT Tokenをフロント側へ送る。
- 一度レコードを全件削除してから操作したところ、PrismaでDBがないというエラーが発生したため、新たにマイグレーションとPrismaのコードを生成し、DBは復活した。
- 一度はJWT Token付与に成功したのに、再度エラーが起きて付与できなくなった。しかし以下の対処法で解決した。
```
● strategy localがないというエラー
=> passportのimportを差し替えることで解決。
● 500系エラー 。ネットワークで404のエラーも起きている状態。
=> デバッグして3003が他で使われていたため、serverをキル・再起動して解決した。
=> JWT Tokenもログインとともに無事付与されていることを確認済み。
```