### PR TITLE
#18 アクセストークンを用いたときのみユーザー一覧を取得する実装をした

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,16 +33,21 @@ app.listen(3003, () => {
 });
 
 //一覧取得
-app.get('/users', async (req: express.Request, res: express.Response) => {
-  const users = await prisma.user.findMany({
-    take: 10,
-    orderBy: {
-      createdAt: 'desc',
-    },
-  });
+app.get(
+  '/users',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    console.log('user: ', req.user);
+    const users = await prisma.user.findMany({
+      take: 10,
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
 
-  res.json({ users });
-});
+    res.json({ users });
+  }
+);
 
 //仮登録時にユーザーがメールアドレスを登録する
 app.post(


### PR DESCRIPTION
# Issue URL

#18

# このPRの対応範囲

- アクセストークンを用いたときのみユーザー一覧を取得する実装をした
- 実際に意図どおりに動くかをテストした

# 変更理由・変更内容

- ログアウト状態や、本人以外のユーザーが`/users `にアクセスした際に、ユーザー情報が取得できてしまわないよう、アクセストークン(JWT)を用いたときのみユーザー一覧を取得する実装をした

- また他のユーザーや仮のログアウト状態を作ったときにユーザー情報がローカルホストのアプリケーション内にないことを確認した