### PR TITLE
#22 パスワード再設定の実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,23 +35,6 @@ app.listen(3003, () => {
   console.log('Start on port 3003.');
 });
 
-// password再設定の際にjwtがあるか確認してからページにアクセスさせる
-app.get(
-  '/reset_password',
-  passport.authenticate('jwt', { session: false }),
-  async (req: express.Request, res: express.Response) => {
-    console.log('user: ', req.user);
-    const users = await prisma.user.findMany({
-      take: 1,
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
-
-    res.json({ users });
-  }
-);
-
 //一覧取得
 app.get(
   '/users',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { sendNoticeRegistrationAuthPassword } from './mailSenderCompleteRegistra
 import { validate } from 'email-validator';
 import { prisma } from '../src/prisma';
 import AuthRouter from './route/AuthRouter';
+import PasswordRouter from './route/PasswordRouter';
+
 import bcrypt from 'bcrypt';
 
 const app: express.Express = express();
@@ -27,10 +29,28 @@ app.use(passport.initialize());
 
 // routerを追加
 app.use('/auth', AuthRouter); // /authから始まるURL
+app.use('/password', PasswordRouter);
 
 app.listen(3003, () => {
   console.log('Start on port 3003.');
 });
+
+// password再設定の際にjwtがあるか確認してからページにアクセスさせる
+app.get(
+  '/reset_password',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    console.log('user: ', req.user);
+    const users = await prisma.user.findMany({
+      take: 1,
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    res.json({ users });
+  }
+);
 
 //一覧取得
 app.get(

--- a/src/route/AuthRouter.ts
+++ b/src/route/AuthRouter.ts
@@ -3,6 +3,9 @@ import express from 'express';
 
 import jwt from 'jsonwebtoken';
 import passport from 'passport';
+import { prisma } from '../prisma';
+
+import bcrypt from 'bcrypt';
 
 const router = express.Router();
 
@@ -11,7 +14,7 @@ router.post(
   passport.authenticate('local', {
     session: false,
   }),
-  async (req, res, next) => {
+  async (req: express.Request, res: express.Response, next) => {
     // 1 jwtのtokenを作成 passwordはペイロードに含めない
     const user = req.user as User;
     const payload = { email: user.email, id: user.id };
@@ -24,6 +27,43 @@ router.post(
     );
     res.json({ token });
     //12h以降のrefreshTokenを用意する。
+  }
+);
+
+// password再設定の際にjwtがあるか確認してからページにアクセスさせる
+router.post(
+  '/password_reset',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    console.log('user: ', req.user);
+    const userId = (req.user as any).id;
+
+    // currentPassword, newPasswordをボディから抽出
+    const { currentPassword, newPassword } = req.body;
+
+    // userId を用いてユーザーデータをDBから取得する なかったらエラーになるようにする
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+    });
+
+    // 現在のユーザーのパスワード(user.password)と currentPassword を比較する
+    if (!currentPassword) {
+      throw new Error('現在のパスワードが不正です');
+    }
+    const isOK = await bcrypt.compare(currentPassword, user?.password);
+    if (!isOK) {
+      throw new Error('現在のパスワードが不正です');
+    }
+
+    // newPassword を暗号化し、DBに保存する
+    const password = await bcrypt.hash(newPassword, 10);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { password: password },
+    });
+
+    res.json({ message: 'パスワード変更完了しました' });
   }
 );
 

--- a/src/route/PasswordRouter.ts
+++ b/src/route/PasswordRouter.ts
@@ -1,0 +1,38 @@
+import { User } from '@prisma/client';
+import express from 'express';
+import { prisma } from '../../src/prisma';
+import jwt from 'jsonwebtoken';
+import passport from 'passport';
+
+const router = express.Router();
+
+// currentPassword newPasswordがフロントからやってくる
+router.post(
+  '/reset',
+  passport.authenticate('jwt', {
+    session: false,
+  }),
+  async (req, res, next) => {
+    const user = req.user as User;
+    const currentPassword = user.password;
+
+    const password = await prisma.user.findFirst({
+      where: { password: currentPassword },
+    });
+    if (!password) {
+      throw new Error('不正な入力です');
+    }
+    // currentPasswordがDBのpasswordと一致したらnewPasswordを登録
+    await prisma.user.create({
+      data: {
+        password: newPassword,
+      },
+    });
+    await res.redirect(
+      `${process.env.FRONTEND_TOP_URL}/reset_password_success`
+    );
+    res.json({});
+  }
+);
+
+export default router;


### PR DESCRIPTION
# Issue URL

#22 

# このPRの対応範囲

- アクセストークンがある場合のみ、パスワードを再設定する
- テストユーザーでprisma studioのパスワードを比較の上、パスワードを再設定できたことを確認した。

# 変更理由・変更内容

- アクセストークンがある場合のみ再設定のページへアクセスできるように実装する予定だったが、それについてはまた別のIssueで実装することにし、今回のPRでは一旦、下記のようにパスワード再設定ができることのみに的を絞って実装した。

- フロントから新旧パスワードを受け取って再登録する実装