### PR TITLE
#26 ユーザーの名前をprismaに登録できたことを確認した

### DIFF
--- a/prisma/migrations/20220816071453_added_username/migration.sql
+++ b/prisma/migrations/20220816071453_added_username/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "userName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Registration {
 model User {
   id String @id @default(uuid())
   email String @unique
+  userName String?
   password String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt()

--- a/src/@types/express.d.ts
+++ b/src/@types/express.d.ts
@@ -1,0 +1,4 @@
+export interface RequestUser {
+  email: string;
+  id: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,35 @@ app.get(
   }
 );
 
+// userNameを登録する
+app.post(
+  '/users',
+  // passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const email = req.body.email;
+    const userName = req.body.userName;
+    console.log('userのemail,userName：', email, userName);
+
+    if (!validate(email)) {
+      // メールアドレスの形式が正しくない時
+      throw new Error('データが不正です。');
+    }
+    try {
+      await prisma.user.update({
+        where: { email },
+        data: { userName },
+      });
+
+      await res.send({ message: 'ユーザー名を変更しました' });
+      // await res.redirect(
+      //   `${process.env.FRONTEND_URL}/?users=${}`
+      // );
+    } catch (err) {
+      throw err;
+    }
+  }
+);
+
 //仮登録時にユーザーがメールアドレスを登録する
 app.post(
   '/registrations',

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -61,6 +61,10 @@ router.get(
 );
 
 // userNameを登録する
+router.param('id', function (req, res, next, id) {
+  next();
+});
+
 router.post(
   '/:id',
   passport.authenticate('jwt', { session: false }),

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -61,11 +61,8 @@ router.get(
 );
 
 // userNameを登録する
-router.param('id', function (req, res, next, id) {
-  next();
-});
 
-router.post(
+router.put(
   '/:id',
   passport.authenticate('jwt', { session: false }),
   async (req: express.Request, res: express.Response) => {

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -62,29 +62,25 @@ router.get(
 
 // userNameを登録する
 router.post(
-  '/',
+  '/:id',
   passport.authenticate('jwt', { session: false }),
   async (req: express.Request, res: express.Response) => {
-    const email = req.body.email;
+    const id = req.params.id;
+    const userId = (req.user as RequestUser)?.id;
     const userName = req.body.userName;
-    console.log('userのemail,userName：', email, userName);
+    console.log('userのusedId,userName：', id, userName);
 
-    if (!validate(email)) {
-      // メールアドレスの形式が正しくない時
-      throw new Error('データが不正です。');
-    }
-    try {
-      await prisma.user.update({
-        where: { email },
-        data: { userName },
-      });
+    if (userId === id) {
+      try {
+        await prisma.user.update({
+          where: { id },
+          data: { userName },
+        });
 
-      res.send({ message: 'ユーザー名を変更しました' });
-      // await res.redirect(
-      //   `${process.env.FRONTEND_URL}/?users=${}`
-      // );
-    } catch (err) {
-      throw err;
+        res.send({ message: 'ユーザー名を変更しました' });
+      } catch (err) {
+        throw err;
+      }
     }
   }
 );

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -1,0 +1,91 @@
+import { User } from '@prisma/client';
+import express from 'express';
+
+import passport from 'passport';
+import { prisma } from '../prisma';
+
+import { validate } from 'email-validator';
+import { RequestUser } from '../@types/express';
+
+const router = express.Router();
+
+//一覧取得
+router.get(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    // 本当は他のユーザーの情報はみれないようにする
+    console.log('user: ', req.user);
+    const users = await prisma.user.findMany({
+      take: 10,
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    res.json({ users });
+  }
+);
+
+router.get(
+  '/:id',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const id = req.params.id;
+    const userId = (req.user as RequestUser)?.id;
+    if (userId === id) {
+      const user = await prisma.user.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          userName: true,
+          email: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      res.json({ data: user });
+    } else {
+      const user = await prisma.user.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          userName: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      res.json({ data: user });
+    }
+  }
+);
+
+// userNameを登録する
+router.post(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const email = req.body.email;
+    const userName = req.body.userName;
+    console.log('userのemail,userName：', email, userName);
+
+    if (!validate(email)) {
+      // メールアドレスの形式が正しくない時
+      throw new Error('データが不正です。');
+    }
+    try {
+      await prisma.user.update({
+        where: { email },
+        data: { userName },
+      });
+
+      res.send({ message: 'ユーザー名を変更しました' });
+      // await res.redirect(
+      //   `${process.env.FRONTEND_URL}/?users=${}`
+      // );
+    } catch (err) {
+      throw err;
+    }
+  }
+);
+export default router;


### PR DESCRIPTION
# Issue URL

#26 

# このPRの対応範囲

- #26 のとおり、名前を登録するAPIを作成し、実際に名前がPrismaに登録できたかを確認する

# 変更内容・変更理由

- 見通しをよくするため、`app.post('/ users',()=>..)`を`UserRouter.ts`にまとめた。
- セキュリティの問題から、JWTトークンを使わないと`/users`からユーザー情報を取得できないようにした。
- パスパラメータでフロント側からuserIdの受け渡しをするようにした。
- 名前を登録するAPIを作成し、実際に名前がPrismaに登録できたかを確認することに成功した。
- また、登録された名前が永続化されていることも確認した。