### PR TITLE
#28 例え登録・読み出しのAPI作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/mysql": "^2.15.21",
         "@types/uuid": "^8.3.4",
         "bcrypt": "^5.0.1",
+        "date-fns": "^2.29.2",
         "dotenv": "^16.0.1",
         "email-validator": "^2.0.4",
         "express": "^4.18.1",
@@ -656,6 +657,18 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.2.tgz",
+      "integrity": "sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1371,9 +1384,9 @@
       "dev": true
     },
     "node_modules/minipass": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
-      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2782,6 +2795,11 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "date-fns": {
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.2.tgz",
+      "integrity": "sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3330,9 +3348,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
-      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "requires": {
         "yallist": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/mysql": "^2.15.21",
     "@types/uuid": "^8.3.4",
     "bcrypt": "^5.0.1",
+    "date-fns": "^2.29.2",
     "dotenv": "^16.0.1",
     "email-validator": "^2.0.4",
     "express": "^4.18.1",

--- a/prisma/migrations/20220825140239_create_model_tatoe/migration.sql
+++ b/prisma/migrations/20220825140239_create_model_tatoe/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "Tatoe" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Tatoe_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tatoe_userId_key" ON "Tatoe"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Tatoe" ADD CONSTRAINT "Tatoe_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20220826043612_add_time_to_tatoe/migration.sql
+++ b/prisma/migrations/20220826043612_add_time_to_tatoe/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Tatoe` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Tatoe" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/prisma/migrations/20220828044514_add_title_shortparaphrase_description/migration.sql
+++ b/prisma/migrations/20220828044514_add_title_shortparaphrase_description/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Tatoe" ADD COLUMN     "description" TEXT,
+ADD COLUMN     "shortParaphrase" TEXT,
+ADD COLUMN     "title" TEXT;

--- a/prisma/migrations/20220830051207_delete_unique_key_at_user_id_on_tatoe/migration.sql
+++ b/prisma/migrations/20220830051207_delete_unique_key_at_user_id_on_tatoe/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Tatoe_userId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,7 @@ model User {
 model Tatoe {
   id String @id @default(uuid())
   user User @relation(fields: [userId],references: [id])
-  userId String @unique
+  userId String
   title String?
   shortParaphrase String?
   description String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,4 +24,11 @@ model User {
   password String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt()
+  tatoe Tatoe?
+}
+
+model Tatoe {
+  id String @id @default(uuid())
+  user User @relation(fields: [userId],references: [id])
+  userId String @unique
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,7 @@ model User {
   password String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt()
-  tatoe Tatoe?
+  tatoe Tatoe[]
 }
 
 model Tatoe {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,4 +31,9 @@ model Tatoe {
   id String @id @default(uuid())
   user User @relation(fields: [userId],references: [id])
   userId String @unique
+  title String?
+  shortParaphrase String?
+  description String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt()
 }

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,0 +1,12 @@
+import { format } from 'date-fns';
+
+const dateFormat = {
+  date: "yyyy-MM-dd'T'HH:mm:ss",
+} as const;
+
+type DateFormat = typeof dateFormat[keyof typeof dateFormat];
+
+type FormattedDate = (date: Date, format: DateFormat) => DateFormat;
+
+export const formatDate: FormattedDate = (date, dateFormat): DateFormat =>
+  format(date, dateFormat) as DateFormat;

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,12 +1,12 @@
 import { format } from 'date-fns';
 
-const dateFormat = {
+export const dateFormat = {
   date: "yyyy-MM-dd'T'HH:mm:ss",
 } as const;
 
-type DateFormat = typeof dateFormat[keyof typeof dateFormat];
+export type DateFormat = typeof dateFormat[keyof typeof dateFormat];
 
-type FormattedDate = (date: Date, format: DateFormat) => DateFormat;
+export type FormattedDate = (date: Date, format: DateFormat) => DateFormat;
 
 export const formatDate: FormattedDate = (date, dateFormat): DateFormat =>
   format(date, dateFormat) as DateFormat;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ app.use(
 app.use(passport.initialize());
 
 // routerを追加
-app.use('/auth', AuthRouter); // /authから始まるURL
+app.use('/auth', AuthRouter);
 app.use('/users', UserRouter);
 
 app.listen(3003, () => {
@@ -47,7 +47,6 @@ app.post(
       const registration = await prisma.registration.create({
         data: { email },
       });
-      //ユーザーの入力したemailとtokenを受け取ったら仮登録メールが飛ぶ
       res.send({ registrationToken: registration.token });
       await sendRegistrationAuthEmail(registration.token, registration.email);
     } catch (err) {
@@ -84,7 +83,6 @@ app.get(
     //ユーザーのメールアドレスが確認できたとき、メールアドレスのパラメータ付きのURLへリダイレクト
     const email = req.body.email as string;
     try {
-      // update を行う前にすでに　confirmedAt が null ではないか、DBから取得をして確認する
       const registration = await prisma.registration.findUnique({
         where: { token },
       });
@@ -95,7 +93,7 @@ app.get(
         throw new Error(',...');
       } else {
         await prisma.registration.update({
-          where: { token, email }, //既に確認された人はここでエラーになる
+          where: { token, email },
           data: { confirmedAt: new Date() },
         });
         res.redirect(
@@ -104,7 +102,6 @@ app.get(
       }
     } catch (err) {
       throw err;
-      //エラーの場合はエラーページへ遷移する
     }
   }
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { validate } from 'email-validator';
 import { prisma } from '../src/prisma';
 import AuthRouter from './route/AuthRouter';
 import UserRouter from './route/UserRouter';
-
+import TatoeRouter from './route/TatoeRouter';
 const app: express.Express = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -24,10 +24,16 @@ app.use(
 );
 app.use(passport.initialize());
 
+/**
+ *
+ * POST /users/:userId/tatoe -> ユーザーのたとえを作成する -> 他の人たとえを作成する /users/abc/tatoe
+ * POST /tatoe -> たとえを作成する
+ */
+
 // routerを追加
 app.use('/auth', AuthRouter);
 app.use('/users', UserRouter);
-
+app.use('/tatoe', TatoeRouter);
 app.listen(3003, () => {
   console.log('Start on port 3003.');
 });

--- a/src/passport.ts
+++ b/src/passport.ts
@@ -3,7 +3,7 @@ import { prisma } from '../src/prisma';
 import { Strategy as StrategyLocal } from 'passport-local';
 import { ExtractJwt, Strategy as StrategyJWT } from 'passport-jwt';
 
-import bcrypt from 'bcrypt';
+const bcrypt = require('bcrypt');
 
 passport.use(
   new StrategyLocal(
@@ -11,14 +11,14 @@ passport.use(
     async (email: string, password: string, done) => {
       const user = await prisma.user.findUnique({ where: { email } });
       if (!user) {
-        return done(new Error('ログイン情報が正しくありません。'), null);
+        return done(new Error('ログイン情報が正しくありません。1'), null);
       }
       const isOK = await bcrypt.compare(password, user?.password);
 
       if (isOK) {
         return done(null, user); //ログイン成功時はfalseの部分がユーザー情報に書き換わる。失敗時はfalse
       } else {
-        return done(new Error('ログイン情報が正しくありません。'), null);
+        return done(new Error('ログイン情報が正しくありません。2'), null);
       }
     }
   )

--- a/src/route/AuthRouter.ts
+++ b/src/route/AuthRouter.ts
@@ -5,8 +5,9 @@ import jwt from 'jsonwebtoken';
 import passport from 'passport';
 import { prisma } from '../prisma';
 
-import bcrypt from 'bcrypt';
 import { sendNoticeRegistrationAuthPassword } from '../mailSenderCompleteRegistration';
+
+const bcrypt = require('bcrypt');
 
 const router = express.Router();
 
@@ -42,6 +43,7 @@ router.post(
 
     // currentPassword, newPasswordをボディから抽出
     const { currentPassword, newPassword } = req.body;
+    console.log('currentPassword, newPassword', currentPassword, newPassword);
 
     // userId を用いてユーザーデータをDBから取得する なかったらエラーになるようにする
     const user = await prisma.user.findUniqueOrThrow({

--- a/src/route/TatoeRouter.ts
+++ b/src/route/TatoeRouter.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import passport from 'passport';
 import { RequestUser } from '../@types/express';
 import { prisma } from '../prisma';
-import { formatDate } from '../date';
+import { DateFormat, dateFormat, formatDate, FormattedDate } from '../date';
 const router = express.Router();
 
 // TODO GET /totae -> 全ての人の tatoe 一覧
@@ -38,6 +38,8 @@ router.post(
         description,
       },
     });
+    // const createdAt = tatoe.createdAt;
+    // const formattedCreatedAt = formatDate(createdAt, dateFormat);
     res.json({ data: tatoe });
   }
 );

--- a/src/route/TatoeRouter.ts
+++ b/src/route/TatoeRouter.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import passport from 'passport';
+import { prisma } from '../prisma';
+
+const router = express.Router();
+
+// TODO GET /totae -> 全ての人の tatoe 一覧
+
+router.get(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const tatoe = await prisma.tatoe.findMany({
+      take: 100,
+      select: {
+        id: true,
+        user: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+    res.json({ tatoe });
+  }
+);
+
+//  TODO GET /totae/hoge -> id が hoge の tatoe を取得
+// /tatoe/:id => userIdをフロントから運んでもらう
+
+//  TODO POST /totae -> 自分の tatoe を作成
+
+//  TODO PUT /tatoe/hoge -> id が hoge の tatoe を更新（作成者が自分自身）
+
+//  TODO DELETE /tatoe/hoge -> id が hoge の tatoe を削除（自分が作ったもののみ許可）
+export default router;

--- a/src/route/TatoeRouter.ts
+++ b/src/route/TatoeRouter.ts
@@ -1,36 +1,46 @@
 import express from 'express';
 import passport from 'passport';
+import { RequestUser } from '../@types/express';
 import { prisma } from '../prisma';
-
+import { formatDate } from '../date';
 const router = express.Router();
 
 // TODO GET /totae -> 全ての人の tatoe 一覧
 
-router.get(
-  '/',
-  passport.authenticate('jwt', { session: false }),
-  async (req: express.Request, res: express.Response) => {
-    const tatoe = await prisma.tatoe.findMany({
-      take: 100,
-      select: {
-        id: true,
-        user: true,
-        userId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
-    res.json({ tatoe });
-  }
-);
+router.get('/', async (req: express.Request, res: express.Response) => {
+  const tatoe = await prisma.tatoe.findMany({
+    take: 100,
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+  res.json({ tatoe });
+});
 
 //  TODO GET /totae/hoge -> id が hoge の tatoe を取得
 // /tatoe/:id => userIdをフロントから運んでもらう
 
 //  TODO POST /totae -> 自分の tatoe を作成
+//  TODO 整形したformatDateをどこで適用するべきか考え中
+
+router.post(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const userId = (req.user as RequestUser)?.id;
+    const { tId, title, shortParaphrase, description } = req.body;
+    const tatoe = await prisma.tatoe.create({
+      data: {
+        userId,
+        id: tId,
+        title,
+        shortParaphrase,
+        description,
+      },
+    });
+    res.json({ data: tatoe });
+  }
+);
 
 //  TODO PUT /tatoe/hoge -> id が hoge の tatoe を更新（作成者が自分自身）
 

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -4,16 +4,13 @@ import express from 'express';
 import passport from 'passport';
 import { prisma } from '../prisma';
 
-import { validate } from 'email-validator';
 import { RequestUser } from '../@types/express';
 import UserTatoeRouter from '../route/UserTatoeRouter';
-import TatoeRouter from '../route/TatoeRouter';
 
 const router = express.Router();
-// (/users)/tatoe
-router.use('/tatoe', TatoeRouter);
-// (/users)/:id/tatoe
-router.use('/:id', UserTatoeRouter);
+
+// (/users)/:userId/tatoe/:tatoeId
+router.use('/:userId/tatoe', UserTatoeRouter);
 
 //一覧取得
 router.get(

--- a/src/route/UserRouter.ts
+++ b/src/route/UserRouter.ts
@@ -6,15 +6,21 @@ import { prisma } from '../prisma';
 
 import { validate } from 'email-validator';
 import { RequestUser } from '../@types/express';
+import UserTatoeRouter from '../route/UserTatoeRouter';
+import TatoeRouter from '../route/TatoeRouter';
 
 const router = express.Router();
+// (/users)/tatoe
+router.use('/tatoe', TatoeRouter);
+// (/users)/:id/tatoe
+router.use('/:id', UserTatoeRouter);
 
 //一覧取得
 router.get(
   '/',
   passport.authenticate('jwt', { session: false }),
   async (req: express.Request, res: express.Response) => {
-    // 本当は他のユーザーの情報はみれないようにする
+    // 本当は他のユーザーの情報はみられないようにする
     console.log('user: ', req.user);
     const users = await prisma.user.findMany({
       take: 10,
@@ -69,7 +75,6 @@ router.put(
     const id = req.params.id;
     const userId = (req.user as RequestUser)?.id;
     const userName = req.body.userName;
-    console.log('userのusedId,userName：', id, userName);
 
     if (userId === id) {
       try {

--- a/src/route/UserTatoeRouter.ts
+++ b/src/route/UserTatoeRouter.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import passport from 'passport';
+import { RequestUser } from '../@types/express';
+import { prisma } from '../prisma';
+
+// TODO GET /users/userId/totae -> userId A の tatoe 一覧が取得できるようにする
+
+const router = express.Router();
+
+// ユーザーの例え一覧取得
+// これで (/users)/:id/tatoe　のはず
+// tatoeとして取得するか個別に title shortParaphrase description?
+
+router.get(
+  '/tatoe',
+  passport.authenticate('jwt', { session: false }),
+  async (req: express.Request, res: express.Response) => {
+    const id = req.params.id;
+    console.log('(/users)/:id/tatoe : id', id);
+    const userId = (req.user as RequestUser)?.id;
+
+    if (userId === id) {
+      const userTatoe = await prisma.user.findUnique({
+        where: { id },
+        include: { tatoe: true },
+      });
+      console.log('userTatoe :', userTatoe);
+
+      res.json({ data: userTatoe });
+    }
+  }
+);
+
+export default router;

--- a/src/route/UserTatoeRouter.ts
+++ b/src/route/UserTatoeRouter.ts
@@ -3,30 +3,26 @@ import passport from 'passport';
 import { RequestUser } from '../@types/express';
 import { prisma } from '../prisma';
 
-// TODO GET /users/userId/totae -> userId A の tatoe 一覧が取得できるようにする
-
 const router = express.Router();
 
 // ユーザーの例え一覧取得
-// これで (/users)/:id/tatoe　のはず
-// tatoeとして取得するか個別に title shortParaphrase description?
-
+// これで (/users)/:userId/tatoe　のはず
 router.get(
-  '/tatoe',
+  '/',
   passport.authenticate('jwt', { session: false }),
   async (req: express.Request, res: express.Response) => {
-    const id = req.params.id;
-    console.log('(/users)/:id/tatoe : id', id);
+    const id = req.params.userId;
     const userId = (req.user as RequestUser)?.id;
 
     if (userId === id) {
-      const userTatoe = await prisma.user.findUnique({
-        where: { id },
-        include: { tatoe: true },
+      const userTatoe = await prisma.tatoe.findMany({
+        where: { userId: id },
       });
       console.log('userTatoe :', userTatoe);
 
       res.json({ data: userTatoe });
+    } else {
+      res.json({ data: [] });
     }
   }
 );


### PR DESCRIPTION
# Issue URL

#28 

# このPRの対応範囲

- #28 の中で、登録と読み出し（ダッシュボード内の例え一覧表示）の部分のAPIを実装する。

# 変更内容・変更理由

- `import bcypt from 'bcypt'`だとエラーになってしまうので、`const bcypt = require('bcypt')`に戻してエラーが解決した。
- 日付のフォーマットのため、`date-fns`を実装検討中。