### PR TITLE
#36 トップページ・詳細ページに例え投稿のユーザー名が表示されるように実装。

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,9 +18,9 @@ model Registration {
 }
 
 model User {
-  id String @id @default(uuid())
+  id String @id @default(uuid()) @relation("id")
   email String @unique
-  userName String?
+  userName String? @relation("userName")
   password String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt()
@@ -29,7 +29,9 @@ model User {
 
 model Tatoe {
   id String @id @default(uuid())
-  user User @relation(fields: [userId],references: [id])
+  user User @relation("id",fields: [userId],references: [id])
+  userNameRelated User @relation("userName",fields: [userName],references: [userName])
+  userName String
   userId String
   title String?
   shortParaphrase String?

--- a/src/route/TatoeRouter.ts
+++ b/src/route/TatoeRouter.ts
@@ -11,6 +11,14 @@ router.get('/', async (req: express.Request, res: express.Response) => {
     orderBy: {
       createdAt: 'desc',
     },
+    include: {
+      user: {
+        select: {
+          userName: true,
+          id: true,
+        },
+      },
+    },
   });
 
   res.json({ tatoe });


### PR DESCRIPTION
# Issue URL

#36 

# このPRの対応範囲

#36 のとおりに実装する。

# 変更理由・変更内容

- 非ログインユーザーとログインユーザー、ゲストユーザーがトップページ、詳細ページで例えを閲覧する際、投稿者の名前が表示されていてほしいので、API側でユーザー名取得のための実装をした。